### PR TITLE
don't fail if default device isn't usable & avoid device leakage

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -52,17 +52,17 @@ base_params_restore <- function() {
 }
 
 attempt_par <- function(...) {
-  if (is_null_device()) {
-    attempt_with_new_device(par(...))
-  } else {
-    par(...)
-  }
+  attempt_(par(...))
 }
 
 attempt_palette <- function(...) {
+  attempt_(palette(...))
+}
+
+attempt_ <- function(expr) {
   if (is_null_device()) {
-    attempt_with_new_device(palette(...))
+    attempt_with_new_device(expr)
   } else {
-    palette(...)
+    force(expr)
   }
 }

--- a/R/base.R
+++ b/R/base.R
@@ -61,7 +61,9 @@ palette_no_new_device <- function(..., fun) {
 
 with_no_new_device <- function(..., fun) {
   dev_before <- dev.cur()
-  res <- fun(...)
+  res <- tryCatch(
+    fun(...), error = warning
+  )
   dev_after <- dev.cur()
   if (dev_before != dev_after) {
     dev.off(dev_after)

--- a/R/base.R
+++ b/R/base.R
@@ -65,7 +65,7 @@ with_no_new_device <- function(..., fun) {
   dev_after <- dev.cur()
   if (dev_before != dev_after) {
     dev.off(dev_after)
-    dev.set(dev_before)
+    if (dev_before > 1) dev.set(dev_before)
   }
   res
 }

--- a/R/base.R
+++ b/R/base.R
@@ -2,15 +2,15 @@ base_palette_set <- function(theme = .globals$theme) {
   base_palette_restore()
   codes <- theme$qualitative
   .globals$base_palette <- if (isTRUE(is.na(codes))) {
-    palette_no_new_device()
+    attempt_palette()
   } else {
-    palette_no_new_device(codes)
+    attempt_palette(codes)
   }
 }
 
 base_palette_restore <- function() {
   if (is.null(.globals$base_palette)) return()
-  palette_no_new_device(.globals$base_palette)
+  attempt_palette(.globals$base_palette)
   rm("base_palette", envir = .globals)
 }
 
@@ -19,11 +19,11 @@ base_params_set <- function(theme = .globals$theme) {
   params <- list()
   bg <- theme$bg
   if (length(bg)) {
-    params <- c(params, par_no_new_device(bg = bg))
+    params <- c(params, attempt_par(bg = bg))
   }
   fg <- theme$fg
   if (length(fg)) {
-    params <- c(params, par_no_new_device(
+    params <- c(params, attempt_par(
       fg = fg,
       col.axis = fg,
       col.lab = fg,
@@ -33,7 +33,7 @@ base_params_set <- function(theme = .globals$theme) {
   }
   font <- theme$font
   if (length(font$family)) {
-    params <- c(params, par_no_new_device(
+    params <- c(params, attempt_par(
       family = font$family,
       cex.axis = font$scale,
       cex.lab = font$scale,
@@ -47,27 +47,22 @@ base_params_set <- function(theme = .globals$theme) {
 
 base_params_restore <- function() {
   if (is.null(.globals$base_params)) return()
-  do.call(par_no_new_device, .globals$base_params)
+  do.call(attempt_par, .globals$base_params)
   rm("base_params", envir = .globals)
 }
 
-par_no_new_device <- function(..., fun) {
-  with_no_new_device(..., fun = par)
-}
-
-palette_no_new_device <- function(..., fun) {
-  with_no_new_device(..., fun = palette)
-}
-
-with_no_new_device <- function(..., fun) {
-  dev_before <- dev.cur()
-  res <- tryCatch(
-    fun(...), error = warning
-  )
-  dev_after <- dev.cur()
-  if (dev_before != dev_after) {
-    dev.off(dev_after)
-    if (dev_before > 1) dev.set(dev_before)
+attempt_par <- function(...) {
+  if (is_null_device()) {
+    attempt_with_new_device(par(...))
+  } else {
+    par(...)
   }
-  res
+}
+
+attempt_palette <- function(...) {
+  if (is_null_device()) {
+    attempt_with_new_device(palette(...))
+  } else {
+    palette(...)
+  }
 }

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -148,8 +148,6 @@ can_render <- function(family, type = c("base", "grid"), dev_fun, dev_name) {
     return(is_available)
   }
 
-  if (is_installed("showtext")) showtext::showtext_begin()
-
   # temporarily disable thematics plot hooks
   # (otherwise, we'd get caught in an infinite loop)
   remove_hooks()
@@ -162,6 +160,7 @@ can_render <- function(family, type = c("base", "grid"), dev_fun, dev_name) {
     dev_fun = dev_fun,
     tryCatch(
       {
+        if (is_installed("showtext")) showtext::showtext_begin()
         if (type == "grid") {
           grid.newpage()
           grid.text("testing", x = 0.5, y = 0.5, gp = gpar(fontfamily = family))

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -184,7 +184,7 @@ can_render <- function(family, type = c("base", "grid"), dev_fun, dev_name) {
 
 # Do our best to map the name of the current device to an
 # actual device function
-get_device_function <- function(name) {
+get_device_function <- function(name = infer_device()) {
 
   # first, resolve known cases where the .Device name
   # doesn't quite map to the relevant function name
@@ -255,4 +255,3 @@ generic_css_families <- function() {
     "-apple-system" , "BlinkMacSystemFont"
   )
 }
-

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -148,26 +148,6 @@ can_render <- function(family, type = c("base", "grid"), dev_fun, dev_name) {
     return(is_available)
   }
 
-  # To see if we have font support on the given device without
-  # generating multiple pages, (temporarily) open the device
-  # to render some text
-  opts <- options(device = dev_fun)
-  on.exit(options(opts), add = TRUE)
-  tmp <- tempfile()
-
-  # dev.off() closes the current device, then sets the current
-  # device to the _next_ device, which isn't necessarily the
-  # previously opened device. So, remember the current device now,
-  # then open a new one, then explicitly set the device to the
-  # previous device (so as to not cause side-effects).
-  dev_cur <- dev.cur()
-  dev_new(filename = tmp)
-  on.exit({
-    dev.off()
-    if (dev_cur > 1) dev.set(dev_cur)
-    unlink(tmp, recursive = TRUE)
-  }, add = TRUE)
-
   if (is_installed("showtext")) showtext::showtext_begin()
 
   # temporarily disable thematics plot hooks
@@ -175,47 +155,33 @@ can_render <- function(family, type = c("base", "grid"), dev_fun, dev_name) {
   remove_hooks()
   on.exit(set_hooks(), add = TRUE)
 
-  # Returns TRUE if relevant plotting code runs without
-  # error or warning about the font family
-  tryCatch(
-    {
-      if (type == "grid") {
-        grid.newpage()
-        grid.text("testing", x = 0.5, y = 0.5, gp = gpar(fontfamily = family))
-      } else {
-        plot(1, family = family)
-      }
-      TRUE
-    },
-    warning = function(w) {
-      !grepl(
-        family,
-        paste(w$message, collapse = "\n"),
-        fixed = TRUE
-      )
-    },
-    error = function(e) { FALSE }
+  # To see if we have font support on the given device without
+  # generating multiple pages, (temporarily) open the device
+  # to render some text
+  attempt_with_device(
+    dev_fun = dev_fun,
+    tryCatch(
+      {
+        if (type == "grid") {
+          grid.newpage()
+          grid.text("testing", x = 0.5, y = 0.5, gp = gpar(fontfamily = family))
+        } else {
+          plot(1, family = family)
+        }
+        TRUE
+      },
+      warning = function(w) {
+        !grepl(
+          family,
+          paste(w$message, collapse = "\n"),
+          fixed = TRUE
+        )
+      },
+      error = function(e) { FALSE }
+    )
   )
 }
 
-
-infer_device <- function() {
-  dev_name <- names(dev.cur())
-  if (!"null device" %in% dev_name) {
-    return(dev_name)
-  }
-  # Temporarily open to a new device to infer what the device *will be*
-  tmp <- tempfile()
-  dev_before <- dev.cur()
-  dev_new(filename = tmp)
-  dev_after <- dev.cur()
-  on.exit({
-    dev.off(dev_after)
-    unlink(tmp, recursive = TRUE)
-    dev.set(dev_before)
-  }, add = TRUE)
-  names(dev_after)
-}
 
 # Do our best to map the name of the current device to an
 # actual device function
@@ -223,17 +189,17 @@ get_device_function <- function(name) {
 
   # first, resolve known cases where the .Device name
   # doesn't quite map to the relevant function name
-  if (identical("win.metafile:", name)) {
+  if ("win.metafile:" == name) {
     return(getFromNamespace("win.metafile", "grDevices"))
   }
 
   # Note that quartz defaults to an on-screen device,
   # so this needs to set to an off-screen type
-  if (identical("quartz_off_screen", name)) {
+  if ("quartz_off_screen" == name) {
     return(grDevices::png)
   }
 
-  if (identical("RStudioGD", name)) {
+  if ("RStudioGD" == name) {
     if (!rstudioapi::isAvailable("1.4")) {
       return(grDevices::png)
     }
@@ -267,7 +233,7 @@ get_device_function <- function(name) {
     devSVG = svglite::svglite,
     # TODO: support cairoDevices? tikz?
     stop(
-      "thematic doesn't (yet) support the '", name, "' graphics device",
+      "thematic doesn't (yet) support the '", name, "' graphics device. ",
       "Please report this error to https://github.com/rstudio/thematic/issues/new",
       call. = FALSE
     )
@@ -276,18 +242,6 @@ get_device_function <- function(name) {
 
 is_ragg_device <- function(dev_name) {
   dev_name %in% paste0("agg_", c("png", "tiff", "ppm", "jpeg"))
-}
-
-dev_new <- function(filename) {
-  # If this is called via thematic_save_plot(), then we know
-  # exactly what function and args to use to clone the device
-  if (length(.globals$device)) {
-    do.call(.globals$device$fun, .globals$device$args)
-    return()
-  }
-  # Most devices use `filename` instead of `file`,
-  # but there are a few exceptions (e.g., pdf(), svglite::svglite())
-  suppressMessages(dev.new(filename = filename, file = filename))
 }
 
 

--- a/R/thematic.R
+++ b/R/thematic.R
@@ -86,7 +86,7 @@ thematic_on <- function(bg = "auto", fg = "auto", accent = "auto",
   # Remember par("bg") now since bg can be modified by the opening of a
   # graphics device, and if that happens before plot time, it'd be too late
   # to base_restore_params()/base_set_params() at plot time
-  .globals$base_params$bg <- par("bg")
+  .globals$base_params$bg <- par_no_new_device("bg")
 
   # Remove any existing hooks before registering them
   # (otherwise, repeated calls to set_hooks will keep adding them)

--- a/R/thematic.R
+++ b/R/thematic.R
@@ -86,7 +86,7 @@ thematic_on <- function(bg = "auto", fg = "auto", accent = "auto",
   # Remember par("bg") now since bg can be modified by the opening of a
   # graphics device, and if that happens before plot time, it'd be too late
   # to base_restore_params()/base_set_params() at plot time
-  .globals$base_params$bg <- par_no_new_device("bg")
+  .globals$base_params$bg <- attempt_par("bg")
 
   # Remove any existing hooks before registering them
   # (otherwise, repeated calls to set_hooks will keep adding them)

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,7 +126,11 @@ attempt_with_device <- function(dev_fun, expr, fail_value = NULL) {
   if (!is.function(dev_fun)) {
     stop("Internal error: dev_fun should be a function.")
   }
-  res <- try(dev_fun(filename = tmp))
+  file_arg <- grep("^file", names(formals(dev_fun)), value = TRUE)
+  if (length(file_arg) != 1) {
+    stop("Internal error: expect graphics device function to have a file/filename argument.")
+  }
+  res <- try(do.call(dev_fun, setNames(list(tmp), file_arg)))
   if (inherits(res, "try-error")) {
     maybe_warn(
       "thematic tried but failed to open a graphics device. If plots don't render ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,6 +123,9 @@ attempt_with_device <- function(dev_fun, expr, fail_value = NULL) {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
   dev_before <- dev.cur()
+  if (!is.function(dev_fun)) {
+    stop("Internal error: dev_fun should be a function.")
+  }
   res <- try(dev_fun(filename = tmp))
   if (inherits(res, "try-error")) {
     maybe_warn(

--- a/tests/testthat/auto_theme_shiny/ggplot2/app.R
+++ b/tests/testthat/auto_theme_shiny/ggplot2/app.R
@@ -1,8 +1,10 @@
 library(shiny)
 library(thematic)
 
-thematic_on(font = "auto")
-onStop(thematic_off)
+thematic_shiny(font = "auto")
+# https://github.com/rstudio/thematic/pull/68
+opts <- options(device = function() stop("boom"))
+onStop(function() options(opts))
 
 ui <- fluidPage(
   titlePanel("Hello"),


### PR DESCRIPTION
Closes #67

## Testing notes

Install `remotes::install_github("rstudio/thematic")` and run the following app. Before this fix, you'd just see an error message in the app. Now you should see a plot (errors and warnings in the console are OK).

```r
library(shiny)
thematic::thematic_shiny(font = "auto")
opts <- options(device = function() stop("boom"))
onStop(function() options(opts))
ui <- fluidPage(
  tags$style(HTML("body{background:black; color:white}")),
  plotOutput("p")
)
server <- function(input, output, session) {
  output$p <- renderPlot(plot(1:10))
}
shinyApp(ui, server)
```

