### PR TITLE
Downgrade systemfonts/sysfonts errors to warnings

### DIFF
--- a/R/gfonts.R
+++ b/R/gfonts.R
@@ -66,7 +66,15 @@ try_register_gfont_cache <- function(family, upgrade) {
         bolditalic = bolditalic
       ),
       error = function(e) {
-        warning(conditionMessage(e))
+        msg <- conditionMessage(e)
+        # It's intentional that we don't check `family %in% system_font()` before
+        # registering since that's a non-trivial cost that must also be paid in
+        # `register_font()`. So, if the failure is due to a system font already
+        # being available, then don't throw since that's irrelevant to the end user
+        # https://github.com/r-lib/systemfonts/blob/e4a98b/R/register_font.R#L60
+        if (!grepl("system font with that family name", msg)) {
+          warning(msg)
+        }
       }
     )
   }

--- a/R/gfonts.R
+++ b/R/gfonts.R
@@ -58,21 +58,31 @@ try_register_gfont_cache <- function(family, upgrade) {
   bolditalic <- font_file("bolditalic")
 
   if (is_installed("systemfonts")) {
-    try(systemfonts::register_font(
-      family, regular,
-      bold = bold,
-      italic = italic,
-      bolditalic = bolditalic
-    ))
+    tryCatch(
+      systemfonts::register_font(
+        family, regular,
+        bold = bold,
+        italic = italic,
+        bolditalic = bolditalic
+      ),
+      error = function(e) {
+        warning(conditionMessage(e))
+      }
+    )
   }
 
   if (is_installed("sysfonts")) {
-    try(sysfonts::font_add(
-      family, regular,
-      bold = bold,
-      italic = italic,
-      bolditalic = bolditalic
-    ))
+    tryCatch(
+      sysfonts::font_add(
+        family, regular,
+        bold = bold,
+        italic = italic,
+        bolditalic = bolditalic
+      ),
+      error = function(e) {
+        warning(conditionMessage(e))
+      }
+    )
   }
 }
 


### PR DESCRIPTION
Suppresses an error message thrown by systemfonts in the case that you try using a Google Font that is already installed as a system font, for example


```r
thematic_on(
  bg = "#212121",
  fg = "#ffffff",
  accent = "#354b63",
  font = font_spec(scale = 1.5, families = "Neucha")
)
```

```r
Error : A system font with that family name already exist
```

(To reproduce, you'd have to install `Neucha` as a system font. Note that plots should still render fine in this case, making the error message superfluous)