### PR TITLE
Be resilient to `getThemeInfo()` not being available or not working as expected

### DIFF
--- a/R/auto.R
+++ b/R/auto.R
@@ -254,6 +254,7 @@ theme_version <- function(...) {
 
 rs_theme_colors <- function() {
   if (!is_rstudio()) return(NULL)
+  if (!rstudioapi::hasFun("getThemeInfo")) return(NULL)
 
   # Hopefully someday this'll return font/accent info
   # https://github.com/rstudio/rstudioapi/issues/174

--- a/R/auto.R
+++ b/R/auto.R
@@ -258,7 +258,8 @@ rs_theme_colors <- function() {
 
   # Hopefully someday this'll return font/accent info
   # https://github.com/rstudio/rstudioapi/issues/174
-  info <- getThemeInfo()
+  info <- tryCatch(getThemeInfo(), error = function(e) NULL)
+  if (is.null(info)) return(NULL)
 
   # These colors were taken manually from the theme preview
   # (they are the token color)

--- a/R/auto.R
+++ b/R/auto.R
@@ -253,12 +253,10 @@ theme_version <- function(...) {
 
 
 rs_theme_colors <- function() {
-  if (!is_rstudio()) return(NULL)
-  if (!rstudioapi::hasFun("getThemeInfo")) return(NULL)
-
+  # Try to get theme info from rstudioapi::getThemeInfo().
   # Hopefully someday this'll return font/accent info
   # https://github.com/rstudio/rstudioapi/issues/174
-  info <- tryCatch(getThemeInfo(), error = function(e) NULL)
+  info <- try_get_theme_info()
   if (is.null(info)) return(NULL)
 
   # These colors were taken manually from the theme preview

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,6 +87,23 @@ in_rstudio_gd <- function(dev_name = infer_device()) {
   "RStudioGD" %in% dev_name
 }
 
+try_get_theme_info <- function() {
+  if (!is_rstudio()) return(NULL)
+  if (!rstudioapi::hasFun("getThemeInfo")) return(NULL)
+
+  tryCatch(
+    getThemeInfo(),
+    error = function(err) {
+      warning(
+        "Could not get current IDE theme info: ",
+        conditionMessage(err),
+        call. = FALSE
+      )
+      NULL
+    }
+  )
+}
+
 # If the current device is null, try to open the default device
 # infer what it'll be
 infer_device <- function() {


### PR DESCRIPTION
This PR adds a specific test for the availability of the `rstudioapi::getThemeInfo()` function before checking for the IDE theme colors.

There are scenarios where `rstudioapi::isAvailable()` will return `TRUE`, but `getThemeInfo()` isn't available. In those cases, `rs_theme_colors()` will error and thematic will fail ungracefully.

This PR adds a check using `rstudioapi::findFun("getThemeInfo")` and then for extra safety wraps the whole thing in a `tryCatch()` in a new `try_get_theme_info()` helper function.