### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -84,7 +84,12 @@ ggthematic_build <- function(p, ggplot_build = NULL, theme = NULL) {
   )
 
   # Remember defaults
-  user_defaults <- lapply(geoms, function(geom) geom$default_aes)
+  if ("get_geom_defaults" %in% getNamespaceExports("ggplot2")) {
+    get_geom_defaults <- get("get_geom_defaults", asNamespace("ggplot2"))
+  } else {
+    get_geom_defaults <- function(geom, ...) geom$default_aes
+  }
+  user_defaults <- lapply(geoms, get_geom_defaults, theme = theme)
 
   # Modify defaults
   Map(function(geom, user_default) {


### PR DESCRIPTION
This PR aims to fix https://github.com/tidyverse/ggplot2/issues/6317.

Briefly, the `default_aes` fields have changed to more often include expressions that are to be evaluated instead of fixed values. This causes a problem for thematic in extracting these defaults, as thematic expects the fixed values.
This PR uses ggplot2's new getter to resolve this information, which makes thematic compatible again with the impending ggplot2 version.

In addition, I've seen some visual changes that appear to be due to a miscalculation of the `axis.ticks.length` family of theme settings. I haven't familiarised myself too much with how thematic derives these, but it might be worth reviewing at some point.

As an aside, ggplot2 has revamped how defaults are determined, which are now mostly determined via the theme. Partially this overlaps with thematic goals, so I think there might be an opportunity to leverage ggplot2's new theme settings to reduce the effort thematic has to do.

We plan to release the new ggplot2 version in May 2025, so I'd be great if we didn't break thematic at that point.