### PR TITLE
Migrate to testthat edition 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     testthat,
     vdiffr (>= 1.0.0),
     withr
+Config/testthat/edition: 3
 Config/Needs/check: shinytest2, callr, sf, ggthemes, patchwork, gridExtra,
     tinytex, devtools, rversions
 Config/Needs/routine: ggrepel, r-lib/evaluate

--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -1,7 +1,3 @@
-# vdiffr ignores failures when
-#   - VDIFFR_RUN_TESTS is "false" (on Travis CI with older versions and dev version of R)
-#   - CI is not set (on CRAN)
-
 # vdiffr:::print_plot.ggplot adds ggplot2::theme_test(), which destroys our theming defaults
 registerS3method(
   "print_plot", "ggplot", function(p, title = "") { print(p) },
@@ -9,6 +5,12 @@ registerS3method(
 )
 
 expect_doppelganger <- function(name, p, ...) {
+  # Visual testing is currently only done locally (via devtools::test()).
+  # This is because we want to .Rbuildignore the _snaps folder, which means
+  # they won't be available when R CMD check is run on CI.
+  # Suppose we could add another step to the CI workflow to run devtools::test(),
+  # but I'm going to wait on that until we agree on a standard (for shiny-workflows).
+  testthat::skip_on_ci()
   vdiffr::expect_doppelganger(name, p, ...)
 }
 

--- a/tests/testthat/test-auto.R
+++ b/tests/testthat/test-auto.R
@@ -1,5 +1,3 @@
-context("auto-config")
-
 test_that("Can influence auto resolution with config", {
   # TODO: add test(s) with different priority settings
   old_config <- auto_config_set(auto_config("black", "white", NA, font = "Pacifico"))

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -1,6 +1,3 @@
-context("base")
-
-
 test_that("base baselines", {
   thematic_local_theme(
     thematic_theme("black", "white", "violet", font_spec("Amatic SC", 1.5, update = TRUE))
@@ -67,4 +64,3 @@ test_that("base baselines", {
   )
 
 })
-

--- a/tests/testthat/test-ggplot.R
+++ b/tests/testthat/test-ggplot.R
@@ -1,5 +1,3 @@
-context("ggplot")
-
 skip_if_not_installed("ggplot2")
 library(ggplot2)
 

--- a/tests/testthat/test-ggthemes.R
+++ b/tests/testthat/test-ggthemes.R
@@ -1,5 +1,3 @@
-context("ggthemes")
-
 skip_if_not_installed("ggplot2")
 
 library(ggplot2)

--- a/tests/testthat/test-lattice.R
+++ b/tests/testthat/test-lattice.R
@@ -1,5 +1,3 @@
-context("lattice")
-
 skip_if_not_installed("lattice")
 library(lattice)
 library(stats)
@@ -81,4 +79,3 @@ test_that("lattice baselines", {
   thematic_local_theme(thematic_theme("black", "white", c("orange", "blue")))
   expect_doppelganger("settings2", show.settings())
 })
-

--- a/tests/testthat/test-sequential-gradient.R
+++ b/tests/testthat/test-sequential-gradient.R
@@ -1,5 +1,3 @@
-context("sequential_gradient")
-
 skip_if_not_installed("ggplot2")
 
 test_that("Sequential gradients works as expected", {

--- a/tests/testthat/test-shinytest.R
+++ b/tests/testthat/test-shinytest.R
@@ -1,5 +1,3 @@
-context("shinytest")
-
 skip_on_cran()
 skip_if_not_installed("shinytest2")
 skip_if_not_installed("callr")
@@ -17,7 +15,7 @@ platform <- getFromNamespace("platform_variant", "shinytest2")(
 
 
 # Default to running tests on macOS
-do_tests <- platform == "mac"
+do_tests <- identical(platform, "mac")
 skip_if_not(as.logical(Sys.getenv("SHINYTEST_RUN_TESTS", do_tests)))
 
 

--- a/tests/testthat/test-state.R
+++ b/tests/testthat/test-state.R
@@ -1,4 +1,3 @@
-context("state management")
 
 test_that("thematic_with_theme()", {
   expect_null(thematic_get_theme())


### PR DESCRIPTION
This PR started out as an attempt to fix the fact that snapshots tests currently always passes since, when `R CMD check` happens, the `_snaps` folder  no longer exists ([and so we end up with a bunch of warnings that snapshots are being added](https://github.com/rstudio/thematic/actions/runs/15615793086/job/43988147441#step:5:331))

Turns out, since `_snaps` is in `.Rbuildignore` (for good reason), there isn't a good way to do the testing as a part of `R CMD check`.

Maybe someday we'll also run `devtools::test()`, but for now, let's just run tests locally.

