### PR TITLE
Update `ggplot_build()` method registration mechanism

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # thematic (development version)
 
+* Fixed an compatibility issue with the new ggplot2 v4.0.0 release. (#164, thanks @teunbrand)
 * Added requirement of ggplot2 >= 3.5.2. (#161, thanks @antivirak)
 
 # thematic 0.1.7

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -12,8 +12,9 @@ ggplot_build_set <- function() {
   if (!is_installed("ggplot2")) return(NULL)
   # Alternative update method if we're dealing with S7
   if ("class_ggplot" %in% getNamespaceExports("ggplot2")) {
-    .globals$ggplot_build <- getFromNamespace("build_ggplot", "ggplot2")
-    registerS3method("ggplot_build", "ggplot", ggthematic_build, asNamespace("ggplot2"))
+    .globals$ggplot_build <- .globals$ggplot_build %||%
+      getS3method("ggplot_build", "ggplot2::ggplot", envir = asNamespace("ggplot2"))
+    registerS3method("ggplot_build", "ggplot2::ggplot", ggthematic_build, asNamespace("ggplot2"))
     return(NULL)
   }
   ggplot_build_restore()
@@ -35,12 +36,12 @@ ggplot_build_set <- function() {
 
 ggplot_build_restore <- function() {
   # Alternative update method if we're dealing with S7
-  if ("class_ggplot" %in% getNamespaceExports("ggplot2")) {
-    dummy_method <- function(plot, ...) NextMethod()
-    registerS3method("ggplot_build", "ggplot", dummy_method, asNamespace("ggplot2"))
-    return(NULL)
-  }
   if (is.function(.globals$ggplot_build)) {
+    if ("class_ggplot" %in% getNamespaceExports("ggplot2")) {
+      registerS3method("ggplot_build", "ggplot2::ggplot", .globals$ggplot_build, asNamespace("ggplot2"))
+      rm("ggplot_build", envir = .globals)
+      return(NULL)
+    }
     ggplot_build <- getFromNamespace("ggplot_build", "ggplot2")
     assign_in_namespace <- assignInNamespace
     ensure_s3_methods_matrix()


### PR DESCRIPTION
This PR aims to fix #163.

We now skip the nonsense with dummy methods and whatnot. We just dynamically swap out S3 methods between the innate `ggplot_build` method for ggplots, and the `ggthematic_build()` function.

I had some font issue which didn't jive well with the visual snapshots, so I didn't inspect and approve them.

Reprex adapted from https://github.com/rstudio/thematic/issues/163#issuecomment-3347972634. The shiny version of the reprex also looks fine to my novice eyes.

``` r
devtools::load_all("~/packages/test/thematic/")
#> ℹ Loading thematic
library(ggplot2)

thematic_on(
  bg = "black", fg = "white", accent = "red",
  font = "Arial"
)

df <- data.frame(x = 1:10, y = 1:10)

ggplot(df, aes(x, y)) +
  geom_bar(aes(fill = y), stat="identity")
#> Warning: The font family 'Arial' doesn't appear to be available as a Google
#> Font. Try manually downloading and installing it on your system. For more info,
#> visit https://github.com/rstudio/thematic#fonts
#> Warning: It seems the current graphics device 'agg_png' is unable to render the
#> requested font family 'Arial'.
```

![](https://i.imgur.com/CHO4gSB.png)<!-- -->

``` r

thematic_off()

ggplot(df, aes(x, y)) +
  geom_bar(aes(fill = y), stat="identity")
```

![](https://i.imgur.com/FfCaOvG.png)<!-- -->

<sup>Created on 2025-09-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


## Pull Request

Before you submit a pull request, please ensure you've completed the following checklist

- [x] Ensure there is an already open and relevant [GitHub issue](https://github.com/rstudio/thematic/issues/new) describing the problem in detail and you've already received some indication from the maintainers that they are welcome to a contribution to fix the problem. This helps us to prevent wasting anyone's time. 

- [ ] Ensure that you have signed the [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement as appropriate. You can send the signed copy to jj@rstudio.com.

- [ ] Add unit tests in the tests/testthat directory.

- [ ] This project uses [roxygen2 for documentation](http://r-pkgs.had.co.nz/man.html). If you've made changes to documentation, run `devtools::document()`.

- [ ] Run `devtools::check()` (or, equivalently, click on Build->Check Package in the RStudio IDE) to make sure your change did not add any messages, warnings, or errors.
    * Note there is a decent chance that some tests were already failing before your changes. Just make sure you haven't introduced any new ones.
    
- [ ] Ensure your code changes follow the style outlined in http://r-pkgs.had.co.nz/style.html

- [ ] Add an entry to NEWS.md concisely describing what you changed.
